### PR TITLE
Feature get order status

### DIFF
--- a/src/main/java/com/oop/service/ShopService.java
+++ b/src/main/java/com/oop/service/ShopService.java
@@ -1,12 +1,15 @@
 package com.oop.service;
 
 import com.oop.order.Order;
+import com.oop.order.OrderRepo;
 import com.oop.order.OrderRepoInterface;
+import com.oop.order.OrderStatus;
 import com.oop.product.Product;
 import com.oop.product.ProductRepo;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class ShopService implements OrderRepoInterface {
     private final OrderRepoInterface orderRepo;
@@ -63,6 +66,10 @@ public class ShopService implements OrderRepoInterface {
 
     public void addProduct(Product product) {
         productRepo.addProduct(product);
+    }
+
+    public List<Order> getOrdersWithOrderStatus(OrderStatus orderStatus) {
+        return orderRepo.getOrders().stream().filter(order -> orderStatus.equals(order.orderStatus())).collect(Collectors.toList());
     }
 
 }

--- a/src/test/java/com/oop/service/ShopServiceTest.java
+++ b/src/test/java/com/oop/service/ShopServiceTest.java
@@ -1,9 +1,6 @@
 package com.oop.service;
 
-import com.oop.order.Order;
-import com.oop.order.OrderItem;
-import com.oop.order.OrderListRepo;
-import com.oop.order.OrderRepo;
+import com.oop.order.*;
 import com.oop.product.Product;
 import com.oop.product.ProductRepo;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +26,9 @@ class ShopServiceTest {
 
     // Create some Orders
     Order order;
+    Order orderWithStatusProgress;
+    Order orderWithStatusInDelivery;
+    Order orderWithStatusCompleted;
 
 
     @BeforeEach
@@ -46,6 +46,20 @@ class ShopServiceTest {
              put(orderItem.productId(), orderItem);
              put(orderItem2.productId(), orderItem2);
          }});
+
+        orderWithStatusProgress = new Order(UUID.randomUUID(), new HashMap<>() {{
+            put(orderItem.productId(), orderItem);
+        }});
+
+        orderWithStatusInDelivery = new Order(UUID.randomUUID(), new HashMap<>() {{
+             put(orderItem.productId(), orderItem);
+             put(orderItem2.productId(), orderItem2);
+         }},null, OrderStatus.IN_DELIVERY);
+
+        orderWithStatusCompleted = new Order(UUID.randomUUID(), new HashMap<>() {{
+            put(orderItem.productId(), orderItem);
+        }},null, OrderStatus.COMPLETED);
+
     }
 
     @Test
@@ -191,6 +205,24 @@ class ShopServiceTest {
         assertEquals(2, shopService.getAllProducts().size());
         shopService.addProduct(product);
         assertEquals(2, shopService.getAllProducts().size());
+    }
+
+    @Test
+    void getOrdersWithOrderStatus_shouldReturnOrders_withOrderStatusOrEmptyList() {
+        shopService = new ShopService(orderRepo, productRepo);
+
+        assertEquals(0, shopService.getOrdersWithOrderStatus(OrderStatus.PROCESSING).size());
+        assertEquals(0, shopService.getOrdersWithOrderStatus(OrderStatus.IN_DELIVERY).size());
+        assertEquals(0, shopService.getOrdersWithOrderStatus(OrderStatus.COMPLETED).size());
+
+        shopService.placingOrder(order);
+        shopService.placingOrder(orderWithStatusProgress);
+        shopService.placingOrder(orderWithStatusCompleted);
+        shopService.placingOrder(orderWithStatusInDelivery);
+
+        assertEquals(2, shopService.getOrdersWithOrderStatus(OrderStatus.PROCESSING).size());
+        assertEquals(1, shopService.getOrdersWithOrderStatus(OrderStatus.IN_DELIVERY).size());
+        assertEquals(1, shopService.getOrdersWithOrderStatus(OrderStatus.COMPLETED).size());
     }
 
 


### PR DESCRIPTION
This pull request adds functionality to filter orders by their status in the `ShopService` class and includes corresponding unit tests in `ShopServiceTest`. The most important changes include introducing a new method to retrieve orders by status and updating tests to verify this functionality.

### New functionality for filtering orders by status:

* Added the `getOrdersWithOrderStatus(OrderStatus orderStatus)` method to filter orders based on their status using Java Streams.

### Updates to unit tests for `ShopService`:

* Added new test orders (`orderWithStatusProgress`, `orderWithStatusInDelivery`, `orderWithStatusCompleted`) with different statuses for testing.
* Added the `getOrdersWithOrderStatus_shouldReturnOrders_withOrderStatusOrEmptyList` test to validate the functionality of filtering orders by status.