### PR TITLE
Feature get oldest order per status

### DIFF
--- a/src/main/java/com/oop/service/ShopService.java
+++ b/src/main/java/com/oop/service/ShopService.java
@@ -83,6 +83,13 @@ public class ShopService {
         return orderRepo.getOrders().stream().filter(order -> orderStatus.equals(order.orderStatus())).collect(Collectors.toList());
     }
 
+    public Order getOldestOrderPerStatus(OrderStatus orderStatus) {
+        return orderRepo.getOrders().stream()
+                .filter(order -> orderStatus.equals(order.orderStatus()))
+                .min((o1, o2) -> o1.orderDate().compareTo(o2.orderDate()))
+                .orElse(null);
+    }
+
 
     // Helper
     public void checkAvailabilityAndStockQuantity (UUID id, int quantity) {

--- a/src/test/java/com/oop/service/ShopServiceTest.java
+++ b/src/test/java/com/oop/service/ShopServiceTest.java
@@ -282,4 +282,31 @@ class ShopServiceTest {
         assertInstanceOf(Instant.class, shopService.getOrder(order.id()).orderDate());
     }
 
+    @Test
+    void getOldestOrderPerStatus_shouldReturnOldestOrderWithGivenStatus() {
+
+        shopService.placingOrder(order);
+        shopService.placingOrder(orderWithStatusCompleted);
+
+        Order oldest = shopService.getOldestOrderPerStatus(OrderStatus.PROCESSING);
+
+        assertEquals(shopService.getOrder(order.id()), oldest);
+    }
+
+    @Test
+    void getOldestOrderPerStatus_shouldReturnNullIfNoOrderWithStatus() {
+        Order result = shopService.getOldestOrderPerStatus(OrderStatus.COMPLETED);
+        assertNull(result);
+    }
+
+    @Test
+    void getOldestOrderPerStatus_shouldReturnOldestWhenMultipleOrdersWithSameStatus() {
+        shopService.placingOrder(order);
+        shopService.placingOrder(orderWithStatusInDelivery.withOrderStatus(OrderStatus.PROCESSING));
+        shopService.placingOrder(orderWithStatusProgress.withOrderStatus(OrderStatus.PROCESSING));
+
+        Order oldest = shopService.getOldestOrderPerStatus(OrderStatus.PROCESSING);
+        assertEquals(shopService.getOrder(order.id()), oldest);
+    }
+
 }


### PR DESCRIPTION
This pull request introduces a new feature to retrieve the oldest order for a given status in the `ShopService` class and adds corresponding unit tests to ensure its functionality. The most important changes include the addition of the `getOldestOrderPerStatus` method in the service layer and comprehensive tests to validate its behavior.

### Feature Addition: Retrieve Oldest Order by Status

* Added the `getOldestOrderPerStatus` method, which filters orders by their status and retrieves the oldest order based on the order date. If no orders match the given status, it returns `null`.

### Unit Tests for New Feature

* Added multiple test cases to validate the behavior of the `getOldestOrderPerStatus` method:
  - Ensures the method returns the oldest order for a given status.
  - Validates that the method returns `null` when no orders match the given status.
  - Confirms the method correctly identifies the oldest order when multiple orders have the same status.